### PR TITLE
Function tag.sh doe not export IMAGE_NAME

### DIFF
--- a/container_ci_suite/engines/podman_wrapper.py
+++ b/container_ci_suite/engines/podman_wrapper.py
@@ -30,7 +30,7 @@ from container_ci_suite.utils import run_command
 class PodmanCLIWrapper(object):
     @staticmethod
     def run_docker_command(
-        cmd, return_output: bool = True, ignore_error: bool = False, shell: bool = True
+        cmd, return_output: bool = True, ignore_error: bool = False, shell: bool = True, debug: bool = False
     ):
         """
         Run docker command:
@@ -40,6 +40,7 @@ class PodmanCLIWrapper(object):
             return_output=return_output,
             ignore_error=ignore_error,
             shell=shell,
+            debug=debug,
         )
 
     @staticmethod

--- a/container_ci_suite/engines/s2i_container.py
+++ b/container_ci_suite/engines/s2i_container.py
@@ -112,7 +112,7 @@ class S2IContainerImage(object):
     def s2i_create_df(
         self, tmp_dir: Path, app_path: str, s2i_args: str, src_image, dst_image: str
     ) -> str:
-        real_app_path = app_path.replace("file://", "") + "/."
+        real_app_path = app_path.replace("file://", "")
         df_content: List = []
         local_scripts: Path = Path("upload/scripts")
         local_app: Path = Path("upload/src")
@@ -156,7 +156,7 @@ class S2IContainerImage(object):
         real_local_app = tmp_dir / local_app
         print(f"Real local app is: {real_local_app} and app_path: {real_app_path}")
         real_local_app.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(real_app_path, real_local_app)
+        shutil.copytree(real_app_path + "/.", real_local_app)
         real_local_scripts = tmp_dir / local_scripts
         bin_dir = local_app / ".s2i" / "bin"
         if bin_dir.exists():

--- a/container_ci_suite/utils.py
+++ b/container_ci_suite/utils.py
@@ -362,9 +362,9 @@ def get_image_name() -> Any:
         return None
     image_id = get_file_content(image_id_file).strip()
     inspect_name = 'docker inspect -f "{{.Config.Labels.name}}" ' + image_id
-    name = run_command(cmd=inspect_name)
+    name = run_command(cmd=inspect_name).strip()
     inspect_version = 'docker inspect -f "{{.Config.Labels.version}}" ' + image_id
-    version = run_command(cmd=inspect_version)
+    version = run_command(cmd=inspect_version).strip()
     return f"{name}:{version}"
 
 

--- a/container_ci_suite/utils.py
+++ b/container_ci_suite/utils.py
@@ -347,9 +347,6 @@ def get_service_image(image_name: str) -> Any:
 
 def check_variables() -> bool:
     ret_value: bool = True
-    if not os.getenv("IMAGE_NAME", None):
-        print("Make sure IMAGE_NAME is defined")
-        ret_value = False
     if not os.getenv("VERSION"):
         print("Make sure VERSION is defined")
         ret_value = False
@@ -357,6 +354,18 @@ def check_variables() -> bool:
         print("Make sure OS is defined")
         ret_value = False
     return ret_value
+
+
+def get_image_name() -> Any:
+    image_id_file = Path(".image-id")
+    if not image_id_file.exists():
+        return None
+    image_id = get_file_content(image_id_file).strip()
+    inspect_name = 'docker inspect -f "{{.Config.Labels.name}}" ' + image_id
+    name = run_command(cmd=inspect_name)
+    inspect_version = 'docker inspect -f "{{.Config.Labels.version}}" ' + image_id
+    version = run_command(cmd=inspect_version)
+    return f"{name}:{version}"
 
 
 def load_shared_credentials(credential: str) -> Any:


### PR DESCRIPTION
Script tag.sh https://github.com/sclorg/container-common-scripts/blob/master/tag.sh does not export
IMAGE_NAME variable. Later on we would like to replace building containers by Python class and this could be a last but not
the first step of migration.

The variable is mandatory.

Instead of it let's get it from <version>/.image-id file


