### PR TITLE
Add packaging into dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+packaging
 pytest
 flexmock
 GitPython


### PR DESCRIPTION
In fact, packaging is already there as a direct dependency of pytest. It's better to have it explicitly defined here so we can use it in the code of CIs to compare versions.