### PR TITLE
Fix deploying imagestreams by s2i. Missing service name

### DIFF
--- a/container_ci_suite/openshift.py
+++ b/container_ci_suite/openshift.py
@@ -402,6 +402,8 @@ class OpenShiftAPI:
 
     def update_template_example_file(self, file_name: str) -> dict:
         json_data = utils.get_json_data(file_name=Path(file_name))
+        if "objects" not in json_data:
+            return json_data
         for object in json_data["objects"]:
             if object["kind"] != "PersistentVolumeClaim":
                 continue
@@ -453,7 +455,7 @@ class OpenShiftAPI:
         return True
 
     def deploy_imagestream_s2i(
-            self, imagestream_file: str, image_name: str, app: str, context: str
+            self, imagestream_file: str, image_name: str, app: str, context: str, service_name: str
     ) -> bool:
         """
         Function deploys imagestreams as s2i application
@@ -473,12 +475,13 @@ class OpenShiftAPI:
             self.update_template_example_file(file_name=local_template)
 
         self.import_is(local_template, name="", skip_check=True)
-        return self.deploy_s2i_app(image_name=image_name, app=app, context=context)
+        return self.deploy_s2i_app(image_name=image_name, app=app, context=context, service_name=service_name)
 
     def deploy_template_with_image(
             self, image_name: str, template: str, name_in_template: str = "", openshift_args=None
     ) -> bool:
         tagged_image = f"{name_in_template}:{self.version}"
+        print(f"deploy_template_with_image: {tagged_image} and {self.shared_cluster}")
         if self.shared_cluster:
             if not self.upload_image_to_external_registry(source_image=image_name, tagged_image=tagged_image):
                 return False

--- a/tests/test_openshift.py
+++ b/tests/test_openshift.py
@@ -88,3 +88,10 @@ class TestOpenShiftCISuite(object):
         assert metadata["labels"]["paas.redhat.com/appcode"] == "SOMETHING-001"
         assert json_data["objects"][0]["spec"]["storageClassName"] == "netapp-nfs"
         assert json_data["objects"][0]["spec"]["volumeMode"] == "Filesystem"
+
+    def test_update_template_without_modeification(self, postgresql_json):
+        flexmock(utils).should_receive("get_json_data").and_return(postgresql_json)
+        flexmock(utils).should_receive("get_shared_variable").and_return("SOMETHING-001")
+        json_data = self.oc_api.update_template_example_file(file_name=f"{DATA_DIR}/postgresql_imagestreams.json")
+        assert json_data
+        assert "objects" not in json_data


### PR DESCRIPTION
During the deploying imagestreams by s2i. service_name for checking is missing.

Also in case 'json_data' does not contain 'objects', then do no update JSON file.
