### PR TITLE
Fix imagestream_s2i, print statuses instead of traceback, apply limits.

### DIFF
--- a/container_ci_suite/engines/openshift.py
+++ b/container_ci_suite/engines/openshift.py
@@ -71,9 +71,18 @@ class OpenShiftOperations:
 
     def print_get_status(self):
         print("Print get all and status:")
-        print(run_oc_command("get all", namespace=self.namespace, json_output=False))
-        print(run_oc_command("status", namespace=self.namespace, json_output=False))
-        print(run_oc_command("status --suggest", namespace=self.namespace, json_output=False))
+        try:
+            print(run_oc_command("get all", namespace=self.namespace, return_output=True, json_output=False))
+        except CalledProcessError:
+            pass
+        try:
+            print(run_oc_command("status", namespace=self.namespace, return_output=True, json_output=False))
+        except CalledProcessError:
+            pass
+        try:
+            print(run_oc_command("status --suggest", namespace=self.namespace, return_output=True, json_output=False))
+        except CalledProcessError:
+            pass
 
     def print_pod_logs(self):
         self.pod_json_data = self.get_pod_status()

--- a/container_ci_suite/utils.py
+++ b/container_ci_suite/utils.py
@@ -331,7 +331,48 @@ def save_tenant_egress_yaml(project_name: str, rules: List[str] = []) -> str:
     temp_file = tempfile.NamedTemporaryFile(prefix="tenant-egress-yml", delete=False)
     with open(temp_file.name, "w") as fp:
         yaml.dump(tenant_egress_yaml, fp)
-    print(f"TenantNamespace yaml file: {temp_file.name}")
+    print(f"TenantNamespaceEgress yaml file: {temp_file.name}")
+    return temp_file.name
+
+
+def save_tenant_limit_yaml() -> str:
+    tenant_limit_yaml = {
+        "apiVersion": "v1",
+        "kind": "LimitRange",
+        "metadata": {
+            "name": "limits",
+        },
+        "spec": {
+            "limits": [
+                {
+                    "type": "Pod",
+                    "max": {
+                        "cpu": "8",
+                        "memory": "8Gi"
+                    },
+                    "min": {
+                        "cpu": "4",
+                        "memory": "2Gi"
+                    }
+                },
+                {
+                    "type": "Container",
+                    "max": {
+                        "cpu": "8",
+                        "memory": "8Gi"
+                    },
+                    "min": {
+                        "cpu": "2",
+                        "memory": "2Gi"
+                    }
+                }
+            ]
+        }
+    }
+    temp_file = tempfile.NamedTemporaryFile(prefix="tenant-limit-yml", delete=False)
+    with open(temp_file.name, "w") as fp:
+        yaml.dump(tenant_limit_yaml, fp)
+    print(f"TenantNamespaceLimits yaml file: {temp_file.name}")
     return temp_file.name
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -198,12 +198,11 @@ class TestContainerCISuiteUtils(object):
         assert check_dnsName
         assert check_deny
 
-    def test_tenantlimites_yaml(self):
-        tenant_limits_yaml = utils.save_tenant_egress_yaml(project_name="123456")
+    def test_tenantlimits_yaml(self):
+        tenant_limits_yaml = utils.save_tenant_limit_yaml()
         with open(tenant_limits_yaml) as fd:
             yaml_load = yaml.safe_load(fd.read())
         assert yaml_load
-        assert yaml_load["metadata"]["name"] == "123456"
         assert len(yaml_load["spec"]["limits"]) == 2
         check_pod_max = False
         check_pod_min = False
@@ -211,14 +210,14 @@ class TestContainerCISuiteUtils(object):
         check_container_min = False
         for limits in yaml_load["spec"]["limits"]:
             if "Pod" in limits["type"]:
-                if limits["max"]["cpu"] == "6" and limits["max"]["memory"] == "4Gi":
+                if limits["max"]["cpu"] == "8" and limits["max"]["memory"] == "8Gi":
                     check_pod_max = True
-                if limits["min"]["cpu"] == "2" and limits["min"]["memory"] == "500Mi":
+                if limits["min"]["cpu"] == "4" and limits["min"]["memory"] == "2Gi":
                     check_pod_min = True
-            if "Pod" in limits["type"]:
-                if limits["max"]["cpu"] == "4" and limits["max"]["memory"] == "2Gi":
+            if "Container" in limits["type"]:
+                if limits["max"]["cpu"] == "8" and limits["max"]["memory"] == "8Gi":
                     check_container_max = True
-                if limits["min"]["cpu"] == "1" and limits["min"]["memory"] == "250Mi":
+                if limits["min"]["cpu"] == "2" and limits["min"]["memory"] == "2Gi":
                     check_container_min = True
         assert check_pod_max
         assert check_pod_min

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -198,6 +198,33 @@ class TestContainerCISuiteUtils(object):
         assert check_dnsName
         assert check_deny
 
+    def test_tenantlimites_yaml(self):
+        tenant_limits_yaml = utils.save_tenant_egress_yaml(project_name="123456")
+        with open(tenant_limits_yaml) as fd:
+            yaml_load = yaml.safe_load(fd.read())
+        assert yaml_load
+        assert yaml_load["metadata"]["name"] == "123456"
+        assert len(yaml_load["spec"]["limits"]) == 2
+        check_pod_max = False
+        check_pod_min = False
+        check_container_max = False
+        check_container_min = False
+        for limits in yaml_load["spec"]["limits"]:
+            if "Pod" in limits["type"]:
+                if limits["max"]["cpu"] == "6" and limits["max"]["memory"] == "4Gi":
+                    check_pod_max = True
+                if limits["min"]["cpu"] == "2" and limits["min"]["memory"] == "500Mi":
+                    check_pod_min = True
+            if "Pod" in limits["type"]:
+                if limits["max"]["cpu"] == "4" and limits["max"]["memory"] == "2Gi":
+                    check_container_max = True
+                if limits["min"]["cpu"] == "1" and limits["min"]["memory"] == "250Mi":
+                    check_container_min = True
+        assert check_pod_max
+        assert check_pod_min
+        assert check_container_max
+        assert check_container_min
+
     @pytest.mark.parametrize(
         "json_data,expected_output",
         [


### PR DESCRIPTION
Print get statuses always instead of Python traceback. We need it.

Create also limit ranges for OpenShift TenantNamespace so we have enough resources for building apps

