### PR TITLE
Add coverage reporting for unit and integration tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,3 +24,49 @@ jobs:
       with:
         tox_env: ${{ matrix.tox_env }}
         dnf_install: gcc rpm-devel git python3-devel
+
+  coverage-unit:
+    name: Coverage (unit tests)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        pip install -e .
+        pip install -r tests/requirements-test.txt
+    - name: Run unit tests with coverage
+      run: make test-coverage-unit
+    - name: Upload unit test coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: unit-tests
+        files: coverage-unit.xml
+        fail_ci_if_error: false
+
+  coverage-integration:
+    name: Coverage (integration tests)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        pip install -e .
+        pip install -r tests/requirements-test.txt
+    - name: Run integration tests with coverage
+      run: make test-coverage-integration
+    - name: Upload integration test coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: integration-tests
+        files: coverage-integration.xml
+        fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage-unit.xml
+coverage-integration.xml
 *.cover
 *.py,cover
 .hypothesis/

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
-.PHONY: build-test test test-in-container clean help test-unit test-integration test-all install-test-deps clean
+.PHONY: build-test test test-in-container clean help test-unit test-integration test-all install-test-deps clean test-coverage test-coverage-unit test-coverage-integration
 
 # Default target
 help:
 	@echo "Container Test Library - Available targets:"
 	@echo ""
-	@echo "  install-test-deps - Install test dependencies"
-	@echo "  test-unit         - Run unit tests only (fast, no Docker required)"
-	@echo "  test-integration  - Run integration tests (requires Docker)"
-	@echo "  test-all          - Run all tests"
-	@echo "  test-coverage     - Run tests with coverage reporting"
-	@echo "  clean             - Clean up test artifacts"
-	@echo "  help              - Show this help message"
+	@echo "  install-test-deps       - Install test dependencies"
+	@echo "  test-unit               - Run unit tests only (fast, no Docker required)"
+	@echo "  test-integration        - Run integration tests (requires Docker)"
+	@echo "  test-all                - Run all tests"
+	@echo "  test-coverage           - Run all tests with coverage reporting"
+	@echo "  test-coverage-unit      - Run unit tests with coverage (output: coverage-unit.xml)"
+	@echo "  test-coverage-integration - Run integration tests with coverage (output: coverage-integration.xml)"
+	@echo "  clean                   - Clean up test artifacts"
+	@echo "  help                    - Show this help message"
 
 TEST_IMAGE_NAME = container-ci-suite-test
 UNAME=$(shell uname)
@@ -28,9 +30,6 @@ test:
 
 test-in-container: build-test
 	$(PODMAN) run --rm --net=host -e DEPLOYMENT=test ${TEST_IMAGE_NAME}
-
-clean:
-	find . -name '*.pyc' -delete
 
 # Install test dependencies
 install-test-deps:
@@ -56,7 +55,17 @@ test-all:
 # Run tests with coverage
 test-coverage:
 	@echo "📊 Running tests with coverage..."
-	cd tests && python3 -m pytest --cov=container_test_lib --cov-report=html --cov-report=term-missing
+	cd tests && python3 -m pytest --cov=container_ci_suite --cov-report=html --cov-report=term-missing
+
+# Run unit tests with coverage (for Codecov - unit-tests flag)
+test-coverage-unit:
+	@echo "📊 Running unit tests with coverage..."
+	cd tests && PYTHONPATH=$(CURDIR) python3 -m pytest -m "not integration" --cov=container_ci_suite --cov-report=xml:../coverage-unit.xml --cov-report=term-missing
+
+# Run integration tests with coverage (for Codecov - integration-tests flag)
+test-coverage-integration:
+	@echo "📊 Running integration tests with coverage..."
+	cd tests && PYTHONPATH=$(CURDIR) python3 -m pytest -m integration --cov=container_ci_suite --cov-report=xml:../coverage-integration.xml --cov-report=term-missing
 
 # Clean up test artifacts
 clean:
@@ -64,5 +73,6 @@ clean:
 	rm -rf .pytest_cache/
 	rm -rf htmlcov/
 	rm -rf .coverage
+	rm -f coverage-unit.xml coverage-integration.xml
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name "*.pyc" -delete

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+flags:
+  unit-tests:
+    carryforward: true
+  integration-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default


### PR DESCRIPTION
- Updated .gitignore to include coverage-unit.xml and coverage-integration.xml.
- Modified Makefile to add targets for running unit and integration tests with coverage.
- Enhanced GitHub Actions workflow to include steps for running coverage reports and uploading results to Codecov.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
