### PR TITLE
Fix calling wait_for_database.

### DIFF
--- a/container_ci_suite/engines/database.py
+++ b/container_ci_suite/engines/database.py
@@ -143,14 +143,21 @@ class DatabaseWrapper:
                 if not expected_output and isinstance(output, str):
                     logger.info("Database is ready (output: '%s')", output.strip())
                     return True
-                if expected_output and isinstance(output, str) and expected_output in output:
+                if (
+                    expected_output
+                    and isinstance(output, str)
+                    and expected_output in output
+                ):
                     logger.info(
                         "Database is ready (output contains expected output: '%s')",
                         expected_output,
                     )
                     return True
                 if isinstance(output, str):
-                    logger.info("Database is ready (without expected output)", output.strip())
+                    logger.info(
+                        "Database is ready (without expected output: '%s')",
+                        output.strip(),
+                    )
                     return True
             except subprocess.CalledProcessError as cpe:
                 logger.error("Error waiting for database: %s", cpe)

--- a/container_ci_suite/engines/database.py
+++ b/container_ci_suite/engines/database.py
@@ -109,6 +109,7 @@ class DatabaseWrapper:
         max_attempts: int = 10,
         sleep_time: int = 3,
         not_shell: bool = True,
+        expected_output: str = "",
     ) -> bool:
         """
         Wait for the database to be ready.
@@ -139,8 +140,17 @@ class DatabaseWrapper:
                     )
                     time.sleep(sleep_time)
                     continue
-                if isinstance(output, str) and output.strip() == "":
-                    logger.info("Database is ready (output: %s)", output)
+                if not expected_output and isinstance(output, str):
+                    logger.info("Database is ready (output: '%s')", output.strip())
+                    return True
+                if expected_output and isinstance(output, str) and expected_output in output:
+                    logger.info(
+                        "Database is ready (output contains expected output: '%s')",
+                        expected_output,
+                    )
+                    return True
+                if isinstance(output, str):
+                    logger.info("Database is ready (without expected output)", output.strip())
                     return True
             except subprocess.CalledProcessError as cpe:
                 logger.error("Error waiting for database: %s", cpe)

--- a/tests/test_database_wrapper.py
+++ b/tests/test_database_wrapper.py
@@ -176,6 +176,115 @@ class TestDatabaseWrapperPostgreSQL:
         assert "ON_ERROR_STOP=1" in call_args
 
 
+class TestWaitForDatabase:
+    """Tests for DatabaseWrapper.wait_for_database."""
+
+    def setup_method(self):
+        self.db = DatabaseWrapper(image_name="mysql:8.0", db_type="mysql")
+        self.cid = "/tmp/test.cid"
+        self.cmd = "mysqladmin ping"
+
+    @patch("container_ci_suite.engines.database.PodmanCLIWrapper.podman_exec_shell_command")
+    def test_wait_for_database_success_without_expected_output(self, mock_exec):
+        """String output with no expected_output filter returns True."""
+        mock_exec.return_value = "mysqld is alive\n"
+
+        result = self.db.wait_for_database(
+            container_id=self.cid,
+            command=self.cmd,
+            expected_output="",
+        )
+
+        assert result is True
+        mock_exec.assert_called_once_with(
+            cid_file_name=self.cid, cmd=self.cmd, not_shell=True
+        )
+
+    @patch("container_ci_suite.engines.database.PodmanCLIWrapper.podman_exec_shell_command")
+    def test_wait_for_database_success_when_expected_substring_present(self, mock_exec):
+        """When expected_output is set, success if it appears in the command output."""
+        mock_exec.return_value = "Status: ready for connections"
+
+        result = self.db.wait_for_database(
+            container_id=self.cid,
+            command=self.cmd,
+            expected_output="ready",
+        )
+
+        assert result is True
+
+    @patch("container_ci_suite.engines.database.time.sleep")
+    @patch("container_ci_suite.engines.database.PodmanCLIWrapper.podman_exec_shell_command")
+    def test_wait_for_database_retries_after_bool_false(self, mock_exec, mock_sleep):
+        """Falsy bool from podman_exec triggers sleep and retry until string output."""
+        mock_exec.side_effect = [False, "ok"]
+
+        result = self.db.wait_for_database(
+            container_id=self.cid,
+            command=self.cmd,
+            max_attempts=5,
+            sleep_time=2,
+        )
+
+        assert result is True
+        assert mock_exec.call_count == 2
+        mock_sleep.assert_called_once_with(2)
+
+    @patch("container_ci_suite.engines.database.time.sleep")
+    @patch("container_ci_suite.engines.database.PodmanCLIWrapper.podman_exec_shell_command")
+    def test_wait_for_database_retries_after_called_process_error(
+        self, mock_exec, mock_sleep
+    ):
+        """CalledProcessError is caught; loop sleeps and retries."""
+        mock_exec.side_effect = [
+            subprocess.CalledProcessError(1, "podman"),
+            "alive",
+        ]
+
+        result = self.db.wait_for_database(
+            container_id=self.cid,
+            command=self.cmd,
+            max_attempts=5,
+            sleep_time=1,
+        )
+
+        assert result is True
+        assert mock_exec.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("container_ci_suite.engines.database.time.sleep")
+    @patch("container_ci_suite.engines.database.PodmanCLIWrapper.podman_exec_shell_command")
+    def test_wait_for_database_false_after_max_attempts(self, mock_exec, mock_sleep):
+        """Returns False when podman keeps returning falsy bool."""
+        mock_exec.return_value = False
+
+        result = self.db.wait_for_database(
+            container_id=self.cid,
+            command=self.cmd,
+            max_attempts=3,
+            sleep_time=1,
+        )
+
+        assert result is False
+        assert mock_exec.call_count == 3
+        assert mock_sleep.call_count == 3
+
+    @patch("container_ci_suite.engines.database.PodmanCLIWrapper.podman_exec_shell_command")
+    def test_wait_for_database_passes_not_shell_false(self, mock_exec):
+        """not_shell=False is forwarded to podman_exec_shell_command."""
+        mock_exec.return_value = "x"
+
+        self.db.wait_for_database(
+            container_id=self.cid,
+            command=self.cmd,
+            not_shell=False,
+        )
+
+        mock_exec.assert_called_once_with(
+            cid_file_name=self.cid, cmd=self.cmd, not_shell=False
+        )
+
+
 class TestDatabaseWrapperCommon:
     """Test common functionality across database types."""
 


### PR DESCRIPTION
Fix calling wait_for_database.

In case not expected_output and output is a string, return True In case expected and output contains a string, return True otherwise return False

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced database readiness detection with configurable expected output matching, improving reliability across varied startup behaviors.
* **Tests**
  * Added comprehensive tests validating readiness detection, retry and failure paths, and argument handling to ensure consistent initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4169353013","data":[{"id":"9fc09f18-c82f-4f84-96e5-c350cb99ce2d","name":"RHEL8 - s2i-perl-container","status":"complete","outcome":"error","runTime":3382.492398,"created":"2026-04-01T12:23:36.684570","updated":"2026-04-01T12:23:36.684578","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fc09f18-c82f-4f84-96e5-c350cb99ce2d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fc09f18-c82f-4f84-96e5-c350cb99ce2d/pipeline.log\">pipeline</a>"]},{"id":"75d841f9-a9f0-40fd-a9bf-d03b8a9597fb","name":"RHEL8 - postgresql-container","runTime":4785.795728,"created":"2026-04-01T12:28:33.858698","updated":"2026-04-01T12:28:33.858706","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/75d841f9-a9f0-40fd-a9bf-d03b8a9597fb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/75d841f9-a9f0-40fd-a9bf-d03b8a9597fb/pipeline.log\">pipeline</a>"]},{"id":"2e3fbb80-6983-43db-a1f9-e33c822fb2bd","name":"RHEL10 - s2i-base-container","status":"complete","outcome":"passed","runTime":888.905999,"created":"2026-04-01T12:22:46.775978","updated":"2026-04-01T12:22:46.775985","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e3fbb80-6983-43db-a1f9-e33c822fb2bd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e3fbb80-6983-43db-a1f9-e33c822fb2bd/pipeline.log\">pipeline</a>"]},{"id":"fb0ddf25-64f2-407f-b16f-ff7bee9de7a8","name":"RHEL10 - nginx-container","status":"complete","outcome":"passed","runTime":904.751736,"created":"2026-04-01T12:07:07.550279","updated":"2026-04-01T12:07:07.550287","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb0ddf25-64f2-407f-b16f-ff7bee9de7a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb0ddf25-64f2-407f-b16f-ff7bee9de7a8/pipeline.log\">pipeline</a>"]},{"id":"99210d27-af9f-440a-82bd-5f1eedc32f85","name":"RHEL10 - s2i-perl-container","status":"complete","outcome":"error","runTime":2804.049618,"created":"2026-04-01T12:27:05.871938","updated":"2026-04-01T12:27:05.871945","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/99210d27-af9f-440a-82bd-5f1eedc32f85\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/99210d27-af9f-440a-82bd-5f1eedc32f85/pipeline.log\">pipeline</a>"]},{"id":"02071303-1085-48d6-8b37-68db4aef0228","name":"RHEL10 - postgresql-container","status":"complete","outcome":"error","runTime":1807.071446,"created":"2026-04-01T12:22:51.422896","updated":"2026-04-01T12:22:51.422902","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02071303-1085-48d6-8b37-68db4aef0228\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02071303-1085-48d6-8b37-68db4aef0228/pipeline.log\">pipeline</a>"]},{"id":"0b4e08de-e008-4984-9197-ee79b3b4b7c5","name":"RHEL9 - s2i-perl-container","status":"complete","outcome":"error","runTime":3529.825193,"created":"2026-04-01T12:05:35.345665","updated":"2026-04-01T12:05:35.345674","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b4e08de-e008-4984-9197-ee79b3b4b7c5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b4e08de-e008-4984-9197-ee79b3b4b7c5/pipeline.log\">pipeline</a>"]},{"id":"27fcd9cf-cbe8-4f79-98e0-24c199579987","name":"RHEL9 - postgresql-container","status":"complete","outcome":"error","runTime":3808.731921,"created":"2026-04-01T12:17:08.076137","updated":"2026-04-01T12:17:08.076145","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/27fcd9cf-cbe8-4f79-98e0-24c199579987\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/27fcd9cf-cbe8-4f79-98e0-24c199579987/pipeline.log\">pipeline</a>"]},{"id":"0199a844-c716-47b3-9613-3580b3b2bc16","name":"RHEL9 - nginx-container","status":"complete","outcome":"error","runTime":4222.540924,"created":"2026-04-01T12:14:47.012461","updated":"2026-04-01T12:14:47.012468","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0199a844-c716-47b3-9613-3580b3b2bc16\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0199a844-c716-47b3-9613-3580b3b2bc16/pipeline.log\">pipeline</a>"]},{"id":"ffe494b4-33d4-4bf9-845e-08e54d18c227","name":"RHEL8 - nginx-container","status":"complete","outcome":"error","runTime":4272.49975,"created":"2026-04-01T12:24:48.472150","updated":"2026-04-01T12:24:48.472159","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffe494b4-33d4-4bf9-845e-08e54d18c227\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffe494b4-33d4-4bf9-845e-08e54d18c227/pipeline.log\">pipeline</a>"]},{"id":"531c6628-75bb-4819-983c-947d36940852","name":"RHEL9 - s2i-base-container","status":"complete","outcome":"passed","runTime":1374.346587,"created":"2026-04-01T12:06:31.331274","updated":"2026-04-01T12:06:31.331283","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/531c6628-75bb-4819-983c-947d36940852\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/531c6628-75bb-4819-983c-947d36940852/pipeline.log\">pipeline</a>"]},{"id":"6f7cdccd-f2f8-4d33-814e-a7c93212ac96","name":"RHEL8 - s2i-base-container","status":"complete","outcome":"passed","runTime":814.913127,"created":"2026-04-01T12:23:07.378569","updated":"2026-04-01T12:23:07.378576","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f7cdccd-f2f8-4d33-814e-a7c93212ac96\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f7cdccd-f2f8-4d33-814e-a7c93212ac96/pipeline.log\">pipeline</a>"]}]} -->