### PR TITLE
Update get_pod_status. In case of CallProcessError

### DIFF
--- a/container_ci_suite/engines/openshift.py
+++ b/container_ci_suite/engines/openshift.py
@@ -33,6 +33,10 @@ from container_ci_suite.utils import (
     load_shared_credentials,
     get_shared_variable,
 )
+from container_ci_suite.exceptions import (
+    OpenShiftGetPodStatusFailed,
+    OpenShiftCommandFailed,
+)
 
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
@@ -88,7 +92,7 @@ class OpenShiftOperations:
         output = ContainerTestLibUtils.run_oc_command("version", json_output=False)
         print(output)
 
-    def get_pod_status(self) -> Dict:
+    def get_pod_status(self, cycle_count: int = 10) -> Dict:
         """
         Get the pod status.
         Returns:
@@ -96,11 +100,18 @@ class OpenShiftOperations:
         """
         # output = OpenShiftAPI.run_oc_command("get all", json_output=False)
         # print(f"oc get all: {output}")
-        output = ContainerTestLibUtils.run_oc_command(
-            "get pods", json_output=True, namespace=self.namespace
-        )
-        # print(f" oc get pods: {output}")
-        return json.loads(output)
+        for _ in range(cycle_count):
+            print(".", sep="", end="")
+            try:
+                output = ContainerTestLibUtils.run_oc_command(
+                    "get pods", json_output=True, namespace=self.namespace
+                )
+                if output:
+                    return json.loads(output)
+            except (CalledProcessError, OpenShiftCommandFailed):
+                pass
+            time.sleep(3)
+        raise OpenShiftGetPodStatusFailed("Failed to get pod status")
 
     def print_get_status(self):
         """
@@ -283,9 +294,13 @@ class OpenShiftOperations:
             True if the build pod is finished, False otherwise
         """
         print("Check if build pod is finished")
-        for count in range(cycle_count):
+        for _ in range(cycle_count):
             print(".", sep="", end="")
-            self.pod_json_data = self.get_pod_status()
+            try:
+                self.pod_json_data = self.get_pod_status()
+            except OpenShiftGetPodStatusFailed:
+                time.sleep(1)
+                continue
             if len(self.pod_json_data["items"]) == 0:
                 time.sleep(1)
                 continue

--- a/container_ci_suite/exceptions.py
+++ b/container_ci_suite/exceptions.py
@@ -8,7 +8,7 @@ from __future__ import print_function, unicode_literals
 
 
 class ContainerCIException(Exception):
-    """ Generic exception when something goes wrong """
+    """Generic exception when something goes wrong"""
 
 
 class ContainerCITimeout(ContainerCIException):
@@ -16,4 +16,16 @@ class ContainerCITimeout(ContainerCIException):
 
 
 class ContainerCICountExceeded(ContainerCIException):
+    pass
+
+
+class ContainerCICommandFailed(ContainerCIException):
+    pass
+
+
+class OpenShiftCommandFailed(ContainerCIException):
+    pass
+
+
+class OpenShiftGetPodStatusFailed(ContainerCIException):
     pass

--- a/tests/test_openshift_ops.py
+++ b/tests/test_openshift_ops.py
@@ -22,9 +22,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import json
+import subprocess
+
+import pytest
 from flexmock import flexmock
+from unittest.mock import patch
 
 from container_ci_suite.engines.openshift import OpenShiftOperations
+from container_ci_suite.exceptions import (
+    OpenShiftCommandFailed,
+    OpenShiftGetPodStatusFailed,
+)
+from container_ci_suite.utils import ContainerTestLibUtils
 
 
 class TestOpenShiftOpsSuite(object):
@@ -77,9 +87,89 @@ class TestOpenShiftOpsSuite(object):
         )
         assert self.oc_ops.get_service_ip("python-testing") is None
 
-    def test_get_pod_status(self):
-        # self.oc_api.get_pod_status()
-        pass
+    def test_get_pod_status_success(self):
+        output = json.dumps({"items": [{"metadata": {"name": "pod-1"}}]})
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "get pods",
+            json_output=True,
+            namespace="container-ci-suite-test",
+        ).and_return(output).once()
+
+        assert self.oc_ops.get_pod_status() == {"items": [{"metadata": {"name": "pod-1"}}]}
+
+    @patch("container_ci_suite.engines.openshift.time.sleep")
+    def test_get_pod_status_retries_on_openshift_error(self, mock_sleep):
+        output = json.dumps({"items": [{"metadata": {"name": "pod-1"}}]})
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "get pods",
+            json_output=True,
+            namespace="container-ci-suite-test",
+        ).and_raise(OpenShiftCommandFailed("oc failed")).and_return(output).times(2)
+
+        assert self.oc_ops.get_pod_status(cycle_count=2) == {
+            "items": [{"metadata": {"name": "pod-1"}}]
+        }
+        mock_sleep.assert_called_once_with(3)
+
+    @patch("container_ci_suite.engines.openshift.time.sleep")
+    def test_get_pod_status_raises_when_retry_count_exhausted(self, mock_sleep):
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "get pods",
+            json_output=True,
+            namespace="container-ci-suite-test",
+        ).and_raise(subprocess.CalledProcessError(1, "oc get pods")).times(2)
+
+        with pytest.raises(OpenShiftGetPodStatusFailed):
+            self.oc_ops.get_pod_status(cycle_count=2)
+        assert mock_sleep.call_count == 2
+
+    def test_print_get_status_success(self):
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "get all",
+            namespace="container-ci-suite-test",
+            json_output=False,
+            ignore_error=True,
+        ).and_return("all resources").once()
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "status --suggest",
+            namespace="container-ci-suite-test",
+            json_output=False,
+            ignore_error=True,
+        ).and_return("status output").once()
+
+        self.oc_ops.print_get_status()
+
+    def test_print_get_status_ignores_called_process_error_for_get_all(self):
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "get all",
+            namespace="container-ci-suite-test",
+            json_output=False,
+            ignore_error=True,
+        ).and_raise(subprocess.CalledProcessError(1, "oc get all")).once()
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "status --suggest",
+            namespace="container-ci-suite-test",
+            json_output=False,
+            ignore_error=True,
+        ).and_return("status output").once()
+
+        self.oc_ops.print_get_status()
+
+    def test_print_get_status_ignores_called_process_error_for_status(self):
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "get all",
+            namespace="container-ci-suite-test",
+            json_output=False,
+            ignore_error=True,
+        ).and_return("all resources").once()
+        flexmock(ContainerTestLibUtils).should_receive("run_oc_command").with_args(
+            "status --suggest",
+            namespace="container-ci-suite-test",
+            json_output=False,
+            ignore_error=True,
+        ).and_raise(subprocess.CalledProcessError(1, "oc status --suggest")).once()
+
+        self.oc_ops.print_get_status()
 
     def test_is_s2i_pod_running(self):
         # self.oc_api.is_s2i_pod_running()


### PR DESCRIPTION
catch this and try one more time

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reliability of pod status monitoring with automatic retry logic that gracefully handles transient failures and temporary connectivity issues during container builds.
  * Improved error handling and recovery mechanisms in pod status checks, allowing builds to continue despite intermittent network or service disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->